### PR TITLE
Reworking to use AG Grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "vue": "^3.4.26"
   },
   "dependencies": {
+    "@ag-grid-community/theming": "^32.3.2",
+    "ag-grid-community": "^32.3.2",
     "antlr4ts": "0.5.0-alpha.4",
     "better-sqlite3": "^11.2.1",
     "json5": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@ag-grid-community/theming':
+        specifier: ^32.3.2
+        version: 32.3.2
+      ag-grid-community:
+        specifier: ^32.3.2
+        version: 32.3.2
       antlr4ts:
         specifier: 0.5.0-alpha.4
         version: 0.5.0-alpha.4
@@ -98,6 +104,12 @@ importers:
         version: 3.4.38(typescript@4.7.4)
 
 packages:
+
+  '@ag-grid-community/core@32.3.2':
+    resolution: {integrity: sha512-m9+x9y1hFoXGklaXxN474pxYc7B/M/hH6pcBtBl+mQpCC4TwUAy516rDsFRH6WqpYiakfBdx1A3mhQbavNEDAQ==}
+
+  '@ag-grid-community/theming@32.3.2':
+    resolution: {integrity: sha512-JTi3r2TpHPHPgbBUQh87OysKD7VfIXrCUKiQxX3OiWJXutX0D0H6eAFwP4C83ourCMRIeZgBqCLhK+TMyzlKJw==}
 
   '@algolia/autocomplete-core@1.9.3':
     resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
@@ -1168,6 +1180,12 @@ packages:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ag-charts-types@10.3.1:
+    resolution: {integrity: sha512-oZvu9vJLk6lmzaYi0TmVVmHFZJpVNFziU0bnllx4wR3muXCmnxz5LouKIZ8CYnNiC7VO5HmHNlFu+0DmEO5zxg==}
+
+  ag-grid-community@32.3.2:
+    resolution: {integrity: sha512-ZrgS7+F0JKV6+sy7VQdt+9xhOJd6TAnXXEmw20ByG6AZdcIDEKBRHW7TfNwUqisXJjGKoaXnYByuMz7rL9PcPg==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -2913,6 +2931,9 @@ packages:
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -3102,6 +3123,16 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@ag-grid-community/core@32.3.2':
+    dependencies:
+      ag-charts-types: 10.3.1
+      tslib: 2.4.0
+
+  '@ag-grid-community/theming@32.3.2':
+    dependencies:
+      '@ag-grid-community/core': 32.3.2
+      tslib: 2.8.1
 
   '@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)(search-insights@2.17.0)':
     dependencies:
@@ -4237,6 +4268,12 @@ snapshots:
       acorn: 8.12.1
 
   acorn@8.12.1: {}
+
+  ag-charts-types@10.3.1: {}
+
+  ag-grid-community@32.3.2:
+    dependencies:
+      ag-charts-types: 10.3.1
 
   agent-base@6.0.2:
     dependencies:
@@ -6325,6 +6362,8 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.4.0: {}
+
+  tslib@2.8.1: {}
 
   tsutils@3.21.0(typescript@4.7.4):
     dependencies:

--- a/src/SqlSealCodeblockHandler.ts
+++ b/src/SqlSealCodeblockHandler.ts
@@ -10,7 +10,6 @@ import { SyncModel } from "./models/sync"
 import { TablesManager } from "./dataLoader/collections/tablesManager"
 import { QueryManager } from "./dataLoader/collections/queryManager"
 
-
 export class SqlSealCodeblockHandler {
     get globalTables() {
         return ['files', 'tags']

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,26 +1,66 @@
 import { App } from "obsidian"
+import { createGrid, GridOptions } from 'ag-grid-community';
+import { themeQuartz } from '@ag-grid-community/theming';
 
-export const displayData = (el: HTMLElement, columns, data, app: App) => {
+export const displayData = (el: HTMLElement, columns: string[], data: Array<Record<string, any>>, app: App) => {
+    // FIXME: rework to always render ui this way and then use gridApi to update the data instead.
     el.empty()
-    const container = el.createDiv({
-        cls: 'sqlseal-table-container'
-    })
-    const table = container.createEl("table")
+    const div = el.createDiv()
+    div.classList.add('sqlseal-grid-wrapper')
+    const grid = div.createDiv()
+    grid.classList.add('ag-theme-quartz')
 
-    // HEADER
-    const header = table.createEl("thead").createEl("tr")
-    columns.forEach(c => {
-        header.createEl("th", { text: c })
-    })
+    // to use myTheme in an application, pass it to the theme grid option
+    const myTheme = themeQuartz
+    .withParams({
+        browserColorScheme: "light",
+        headerFontSize: 14,
+    });
 
-    const body = table.createEl("tbody")
-    data.forEach(d => {
-        const row = body.createEl("tr")
-        columns.forEach(c => {
-            row.createEl("td", { text: parseCell(d[c], app) })
+    const gridOptions: GridOptions = {
+        theme: myTheme,
+        defaultColDef: {
+            resizable: false,
+        },
+        autoSizeStrategy: {
+            type: 'fitGridWidth',
+            defaultMinWidth: 150,
+        },
+        suppressMovableColumns: true,
+        loadThemeGoogleFonts: false,
+        rowData: data,
+        columnDefs: columns.map(c => ({
+            field: c
+        })),
+        domLayout: 'autoHeight'
+    }
 
-        })
-    })
+    // Setup Grid
+    const gridApi = createGrid(
+        grid,
+        gridOptions,
+      );
+    return
+
+    // const container = el.createDiv({
+    //     cls: 'sqlseal-table-container'
+    // })
+    // const table = container.createEl("table")
+
+    // // HEADER
+    // const header = table.createEl("thead").createEl("tr")
+    // columns.forEach(c => {
+    //     header.createEl("th", { text: c })
+    // })
+
+    // const body = table.createEl("tbody")
+    // data.forEach(d => {
+    //     const row = body.createEl("tr")
+    //     columns.forEach(c => {
+    //         row.createEl("td", { text: parseCell(d[c], app) })
+
+    //     })
+    // })
 }
 
 const parseCell = (data: string, app: App) => {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -31,7 +31,9 @@ export const displayData = (el: HTMLElement, columns: string[], data: Array<Reco
         loadThemeGoogleFonts: false,
         rowData: data,
         columnDefs: columns.map(c => ({
-            field: c
+            field: c,
+            cellRenderer: ({ value }: { value: string }) =>  parseCell(value, app),
+            autoHeight: true
         })),
         domLayout: 'autoHeight'
     }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -26,6 +26,7 @@ export const displayData = (el: HTMLElement, columns: string[], data: Array<Reco
             type: 'fitGridWidth',
             defaultMinWidth: 150,
         },
+        pagination: true,
         suppressMovableColumns: true,
         loadThemeGoogleFonts: false,
         rowData: data,

--- a/styles.css
+++ b/styles.css
@@ -6,3 +6,11 @@
     width: 100%;
     border-collapse: collapse;
 }
+
+.sqlseal-grid-wrapper {
+    height: auto;
+}
+
+.edit-block-button {
+    z-index: 1000;
+}


### PR DESCRIPTION
Reworking how SQLSeal is displaying data to use AG Grid Community Version. This allows for way nicer UI and more functionality out of the box like built in pagination and sorting. More configurability will be implemented later like setting default parameters for AG Grid in the settings tab.

Based on the #13 PR.