### PR TITLE
fix: fixing issue with internal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+fix: fix issue with local links not being clickable
+
 # 0.14.1
 fix: fixed the issue where rows with extra data in them (rows with more columns that a header) were not synchronised correctly
 fix: fixed the issue where queries with lowercase SELECT would not work in certain cases.

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -42,25 +42,13 @@ const isLinkLocal = (link: string) => !link?.trim().startsWith('http')
 const generateLink = (config: SqlSealAnchorElement, app: App) => {
     let href = config.href
     if (isLinkLocal(config.href)) {
-        const link = createEl('a', {
-            text: config.name,
-            cls: 'internal-link' // This class is used by Obsidian for internal links
-          });
-          
-          link.addEventListener('click', (event) => {
-            event.preventDefault();
-            // Open the file in the active leaf (same tab)
-            const leaf = app.workspace.getLeaf();
-            const file = app.vault.getFileByPath(config.href)
-            if (!file) {
-                return
-            }
-            leaf.openFile(file);
-          });
-        const encodedPath = encodeURIComponent(config.href);
-        // Create the Obsidian URI
-         href = `app://obsidian.md/${encodedPath}`;
-         return link
+        let fileHref = config.href
+        if (fileHref.endsWith('.md')) {
+            fileHref = fileHref.slice(0, -3)
+        }
+        const vaultName = encodeURIComponent(app.appId);
+        const encodedPath = encodeURIComponent(fileHref);
+        href = `obsidian://open?vault=${vaultName}&file=${encodedPath}`;
     }
     const el = createEl('a', { text: config.name, href: href })
     return el


### PR DESCRIPTION
Fixing issue with internal links not being clickable. It seems adding `internal-link` class to the link changes the way how it was interpreted.
Documentation: https://help.obsidian.md/Extending+Obsidian/Obsidian+URI#Open%20note
Ticket: https://trello.com/c/3moLnbo7