### PR TITLE
fix: queries are not case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 fix: fix issue with local links not being clickable
+fix: query is now less case sensitive. You can use keywords like `TABLE`, `HTML`, `MARKDOWN` in any casing you want
 
 # 0.14.1
 fix: fixed the issue where rows with extra data in them (rows with more columns that a header) were not synchronised correctly

--- a/src/grammar/newParser.ts
+++ b/src/grammar/newParser.ts
@@ -13,6 +13,7 @@ interface ParsedLanguage {
     intermediateContent: string;
 }
 
+// TODO: this should be retwitten to use proper grammar but this seems to work, at least for now :)
 export function parseLanguage(input: string): ParsedLanguage {
     const lines = input.split('\n');
     const result: ParsedLanguage = {
@@ -23,36 +24,34 @@ export function parseLanguage(input: string): ParsedLanguage {
 
     // State tracking
     let currentPosition = 0;
-    let intermediateContentStarted = false;
-    
     // Parse TABLE declarations
     while (currentPosition < lines.length) {
         const line = lines[currentPosition].trim();
-        
+
         // Skip empty lines at the beginning
         if (line === '') {
             currentPosition++;
             continue;
         }
-        
+
         // If we hit SELECT or any other non-TABLE part, break
-        if (!line.startsWith('TABLE')) {
+        if (!line.toUpperCase().startsWith('TABLE')) {
             break;
         }
-        
+
         // Parse TABLE declaration
         // Format: TABLE tableName = file(filename.csv)
-        const tableMatch = line.match(/TABLE\s+(\w+)\s*=\s*file\(([^)]+)\)/);
+        const tableMatch = line.match(/TABLE\s+(\w+)\s*=\s*file\(([^)]+)\)/i);
         if (tableMatch) {
             result.tables.push({
                 tableName: tableMatch[1],
                 fileName: tableMatch[2]
             });
         }
-        
+
         currentPosition++;
     }
-    
+
     // Find the position of SELECT statement
     let selectPosition = -1;
     for (let i = currentPosition; i < lines.length; i++) {
@@ -62,7 +61,7 @@ export function parseLanguage(input: string): ParsedLanguage {
             break;
         }
     }
-    
+
     // Extract intermediate content (if any)
     if (selectPosition > currentPosition) {
         result.intermediateContent = lines
@@ -70,7 +69,7 @@ export function parseLanguage(input: string): ParsedLanguage {
             .join('\n')
             .trim();
     }
-    
+
     // Extract SQL query
     if (selectPosition !== -1) {
         result.queryPart = lines
@@ -84,6 +83,6 @@ export function parseLanguage(input: string): ParsedLanguage {
             .join('\n')
             .trim();
     }
-    
+
     return result;
 }

--- a/src/grammar/parser.test.ts
+++ b/src/grammar/parser.test.ts
@@ -69,19 +69,40 @@ SELECT * FROM a JOIN y ON a.id=y.id`)).toEqual({
         expect(parseLanguage(`
 HTML
 select * from files`)).toEqual({
-    "intermediateContent": "HTML",
-  "queryPart": "select * from files",
-  "tables": [],
-})
+            "intermediateContent": "HTML",
+            "queryPart": "select * from files",
+            "tables": [],
+        })
     })
 
     it('should properly parse query where SELECT is in sPoNgeBoB-cAsE', () => {
         expect(parseLanguage(`
 HTML
 sElEcT * fRoM files`)).toEqual({
-    "intermediateContent": "HTML",
-  "queryPart": "sElEcT * fRoM files",
-  "tables": [],
-})
+            "intermediateContent": "HTML",
+            "queryPart": "sElEcT * fRoM files",
+            "tables": [],
+        })
+    })
+
+    it('should allow for lowercase TABLE syntax', () => {
+        expect(parseLanguage(`
+            
+            table x = file(a.csv)
+
+            html
+
+            select * from files
+            
+            `)).toEqual({
+            'intermediateContent': 'html',
+            'queryPart': 'select * from files',
+            tables: [
+                {
+                    tableName: 'x',
+                    fileName: 'a.csv'
+                }
+            ]
+        })
     })
 })


### PR DESCRIPTION
Fixing issue with queries like the following not working because of case sensitivity:
```
html
select name from files
```

```
table emp = file(emp.csv)
select name from emp
```

Added extra tests to cover similar cases.


Note: the grammar parsing should be rewritten at some point to allow for more complex parsing but for now this seems to work good enough.