### PR TITLE
fix: codeblocks now only watch tables they actually refer to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fix: fix issue with local links not being clickable
 - fix: query is now less case sensitive. You can use keywords like `TABLE`, `HTML`, `MARKDOWN` in any casing you want
 - fix: improved SQL parser - now more complex syntax like recursive CTE, window functions, etc. should work properly. Migrated from `node-sql-parser` to `sql-parser-cst`
+- fix: codeblocks now observe only the tables that are relevant to them instead of all. This should fix some tables refresh too often
 
 # 0.14.1
 - fix: fixed the issue where rows with extra data in them (rows with more columns that a header) were not synchronised correctly

--- a/src/utils/registerObservers.test.ts
+++ b/src/utils/registerObservers.test.ts
@@ -1,0 +1,30 @@
+import { Omnibus } from "@hypersphere/omnibus"
+import { registerObservers } from "./registerObservers"
+
+describe('registerObservers', () => {
+    it('should properly register observers', () => {
+        const bus = new Omnibus()
+        const callback = jest.fn()
+        const tables = ['files', 'tags']
+
+        registerObservers({
+            bus: bus.getRegistrator(),
+            callback,
+            tables,
+            fileName: 'file.md'
+        })
+
+        expect(callback).not.toHaveBeenCalled()
+
+        bus.trigger('change::tagss')
+        expect(callback).not.toHaveBeenCalled()
+
+        bus.trigger('change::tags')
+        bus.trigger('change::files')
+        bus.trigger('file::change::file.md')
+        expect(callback).toHaveBeenCalledTimes(3)
+        
+
+
+    })
+})

--- a/src/utils/registerObservers.ts
+++ b/src/utils/registerObservers.ts
@@ -1,0 +1,16 @@
+import { OmnibusRegistrator } from "@hypersphere/omnibus";
+
+export interface RegisterConfiguration {
+    bus: OmnibusRegistrator,
+    tables: string[],
+    callback: () => void,
+    fileName: string
+}
+
+export const registerObservers = ({ bus, callback, fileName, tables}: RegisterConfiguration) => {
+    bus.offAll()
+    tables.forEach(t => {
+        bus.on(`change::${t}`, callback)
+    })
+    bus.on(`file::change::${fileName}`, callback)
+}


### PR DESCRIPTION
Thanks to the new underlying SQL parser it was much easier to observe only the tables which are being accessed by the query. This should help you with the queries, especially when you have plenty of changes happening across the vault.