### PR TITLE
chore: fixing issue with mobile database naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- fix: database did not load properly when vault name consisted spaces or was in the subfolder (mostly causing issue on mobile)
+
 # 0.25.0 (2025-02-06)
 - feat: you can now generate list of links
 - feat: lists are now properly rendered

--- a/src/database/worker/database.ts
+++ b/src/database/worker/database.ts
@@ -191,10 +191,7 @@ export class WorkerDatabase {
             SQL.FS.mkdir('/sql');
             SQL.FS.mount(sqlFS, {}, '/sql');
 
-            // Removing old database under the generic name
-            indexedDB.deleteDatabase('sqlseal.sqlite')
-
-            const path = `sql/sqlseal___${this.dbName}.sqlite3`
+            const path = `sql/sqlseal___${sanitise(this.dbName)}.db`
 
             let stream = SQL.FS.open(path, 'a+');
             await stream.node.contents.readIfFallback();


### PR DESCRIPTION
Vault names on mobile can have paths including "/" as a name, sanitising them to make sure the file can get created.