### PR TITLE
feat: Add frontmatter links to the links table

### DIFF
--- a/docs/data-sources/vault-data.md
+++ b/docs/data-sources/vault-data.md
@@ -52,3 +52,26 @@ Introduced in 0.20.0
 | `position`      | JSON object containing information about location of the link      |
 | `display_text`  | Text displayed on the page for that link                           |
 | `target_exists` | information if the target file exists. 1 if it exists, 0 otherwise |
+
+#### Frontmatter links
+
+Links that appear in a file's frontmatter (Obsidian properties) contain a `frontmatterKey` property in the `position`
+JSON object. This can be used to identify links that are in the note body or within a specific frontmatter property.
+
+For instance, to query all links to the current file that appear in the body of a note:
+
+```sql
+SELECT * FROM links
+WHERE target = @path
+AND json_extract(position, '$.frontmatterKey') IS NULL
+```
+
+`frontmatterKey` can be used to select links within a specific property. A Map of Content, for instance, may wish to
+show a list of files that list the MOC as a type:
+
+```sql
+LIST
+SELECT a(path) FROM links
+WHERE target = @path
+AND json_extract(position, '$.frontmatterKey') = 'type'
+```

--- a/src/vaultSync/tables/linksTable.ts
+++ b/src/vaultSync/tables/linksTable.ts
@@ -26,10 +26,7 @@ export class LinksFileSyncTable extends AFileSyncTable {
         if (!cache) {
             return []
         }
-        const tags = cache.links
-        if (!tags) {
-            return []
-        }
+        const tags = (cache.links || []).concat(cache.frontmatterLinks || []);
         return tags.map((t) => {
             const targetFile = this.app.metadataCache.getFirstLinkpathDest(t.link, file.path)
             let targetExists = false
@@ -38,10 +35,16 @@ export class LinksFileSyncTable extends AFileSyncTable {
                 target = targetFile.path
                 targetExists = true
             }
+            let position = t.position;
+            if (t.key) {
+                position = {
+                    frontmatterKey: t.key
+                }
+            }
             return {
                 path: file.path,
                 target: target,
-                position: t.position,
+                position: position,
                 display_text: t.displayText,
                 target_exists: targetExists
             }

--- a/src/vaultSync/tables/linksTable.ts
+++ b/src/vaultSync/tables/linksTable.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { FrontmatterLinkCache, LinkCache, TFile } from "obsidian";
 import { AFileSyncTable } from "./abstractFileSyncTable";
 
 export class LinksFileSyncTable extends AFileSyncTable {
@@ -26,29 +26,39 @@ export class LinksFileSyncTable extends AFileSyncTable {
         if (!cache) {
             return []
         }
-        const tags = (cache.links || []).concat(cache.frontmatterLinks || []);
-        return tags.map((t) => {
-            const targetFile = this.app.metadataCache.getFirstLinkpathDest(t.link, file.path)
-            let targetExists = false
-            let target = t.link
-            if (targetFile) {
-                target = targetFile.path
-                targetExists = true
-            }
-            let position = t.position;
-            if (t.key) {
-                position = {
-                    frontmatterKey: t.key
-                }
-            }
-            return {
-                path: file.path,
-                target: target,
-                position: position,
-                display_text: t.displayText,
-                target_exists: targetExists
-            }
-        })
+
+		const links: any[] = (cache.links || []).map((l: LinkCache) => {
+			return {
+				targetLink: l.link,
+				position: l.position,
+				display_text: l.displayText
+			}
+		});
+
+		const frontmatterLinks: any[] = (cache.frontmatterLinks || []).map((l: FrontmatterLinkCache) => {
+			return {
+				targetLink: l.link,
+				position: { frontmatterKey: l.key },
+				display_text: l.displayText
+			}
+		});
+
+		return links.concat(frontmatterLinks).map(({ targetLink, ...reference }) => {
+			const targetFile = this.app.metadataCache.getFirstLinkpathDest(targetLink, file.path)
+			let targetExists = false
+			let target = targetLink
+			if (targetFile) {
+				target = targetFile.path
+				targetExists = true
+			}
+
+			return {
+				path: file.path,
+				target: target,
+				...reference,
+				target_exists: targetExists
+			}
+		})
     }
 
 


### PR DESCRIPTION
Adds links found in frontmatter to the links table, along with links found in the note body. The frontmatter key is added to the `position` attribute with the key `frontmatterKey`. This might be more appropriate in a separate column, as it's not a `position` field. Let me know what you think and I'll extract it if desired.