### PR TITLE
feat: do not nest lists with a single column of data

### DIFF
--- a/src/renderer/ListRenderer.ts
+++ b/src/renderer/ListRenderer.ts
@@ -51,11 +51,12 @@ export class ListRenderer implements RendererConfig {
                 })
 
                 data.forEach((d: any) => {
-                    const row = list.createEl("li", { cls: ['sqlseal-list-element'] }).createEl('ul')
+					const singleCol = columns.length == 1; // Only one column, do not nest lists
+                    const row = singleCol ? list : list.createEl("li", { cls: ['sqlseal-list-element'] }).createEl('ul')
                     columns.forEach((c: any) => {
                         const el = row.createEl("li", {
                             text: createEl('span', { text: c, cls: 'sqlseal-column-name' }) as any, // FIXME: this should be properly typed
-                            cls: ['sqlseal-list-element-single']
+                            cls: singleCol ? ['sqlseal-list-element', 'sqlseal-list-element-single'] : ['sqlseal-list-element-single']
                         })
                         const val = this.cellParser.render(d[c])
                         el.append(val)


### PR DESCRIPTION
When a dataset contains only a single column, nested lists do not look quite right. This change creates only a single list when there's only one column.

Before:

<img width="326" alt="Screenshot 2025-03-18 at 14 22 25" src="https://github.com/user-attachments/assets/e6a49293-89c9-4fbd-ad5e-e976c04a1379" />

After:

<img width="295" alt="Screenshot 2025-03-18 at 14 22 51" src="https://github.com/user-attachments/assets/fe5828fe-a3ab-439d-bbc5-28cdbaa1578f" />

