### PR TITLE
Quick Fix For Missing Frontmatter Tags

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -63,7 +63,9 @@ export default defineConfig({
       {
         text: 'FAQ',
         items: [
-          { text: 'Comparison with Dataview', link: '/faq/comparison-with-dataview' }
+          { text: 'Comparison with Dataview', link: '/faq/comparison-with-dataview' },
+		  { text: 'Understanding Tags', link: '/faq/understanding-tags'}
+
         ]
       },
       {

--- a/docs/data-sources/vault-data.md
+++ b/docs/data-sources/vault-data.md
@@ -23,6 +23,8 @@ Files table consists of the following columns:
 | `file_size`         | Size of the file on disk (in bytes)                                                                                                                                              | 0.18.1        |
 | All file properties | All file properties are also added to the table. All the special characters will be transformed to underscores `_`, so for example `note type` will be accessible as `note_type` |               |
 
+> **Note:** Tags data can exist in two contexts - as file metadata here or as an entry in the tags table. Details [here](../faq/understanding-tags.md)
+
 ### `tags` table
 Tags table consists of the following columns:
 | Column   | Description                                                                                                              | Introduced In |
@@ -30,6 +32,8 @@ Tags table consists of the following columns:
 | `tag`    | Full tag, including `#` symbol. For example `#todo`                                                                      |               |
 | `path`   | Full path of the file the tag belongs to                                                                                 | 0.24.1        |
 | `fileId` | (deprecated) same like `path`. Name changed for compatibility with other tables. Will get removed in the future versions |               |
+
+> **Note:** Tags data can in two contexts - as file metadata or as an entry in this tags table. Details [here](../faq/understanding-tags.md)
 
 ### `tasks` table
 Tasks table consists of the following columns:

--- a/docs/faq/understanding-tags.md
+++ b/docs/faq/understanding-tags.md
@@ -1,0 +1,30 @@
+# Understanding Tags in SQLSeal
+When working with the SQLSeal plugin in Obsidian, tags can appear in two different contexts:
+
+- as a frontmatter property in your files
+- as rows in the `tags` table
+
+It is important to understand what to expect when querying them in these different contexts.
+
+## Tags in Frontmatter
+
+Obsidian’s frontmatter can include a `tags` field to declare tags directly within the YAML metadata at the top of a file.
+
+For example:
+```yaml
+---
+tags: [project, todo]
+---
+```
+
+These tags will appear as a list in the frontmatter and are considered a direct part of the file’s metadata.
+
+In the context of SQLSeal, they will be accessible when you query the files table, but they behave like any other frontmatter property-essentially as a plain list of values.
+
+## Tags in the tags Table
+
+The tags table is specifically designed to capture all tags found within the vault. Each tag in this table is represented as a separate row, along with the file path it’s associated with. For instance, if you have a tag #todo in multiple files, each instance of #todo will be recorded in the tags table, linking it to the respective file.
+
+## In Summary
+
+When using SQLSeal, keep in mind that tags from frontmatter and tags in the tags table serve different purposes and are structured differently. Frontmatter tags are essentially metadata fields of the file and appear as-is in the files table, while the tags table provides a detailed, row-based view of all tags in your vault.

--- a/src/vaultSync/tables/filesTable.ts
+++ b/src/vaultSync/tables/filesTable.ts
@@ -17,7 +17,7 @@ const extractFrontmatterFromFile = (file: TFile, plugin: Plugin): Record<string,
     )
 }
 
-function fileData(file: TFile, { tags: _tags, ...frontmatter }: Record<string, any>) {
+function fileData(file: TFile, { ...frontmatter }: Record<string, any>) {
     return {
         ...frontmatter,
         id: file.path,


### PR DESCRIPTION
tags in frontmatter was being removed from file query results via a destructuring assignment. Removed this destructured assignment.

I am guessing there may be some prior or planned reason for the tags data to be removed (probably as an aggregate value for all tags on in a file perhaps?)