### PR TITLE
feat: New renderer for use with task lists

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { SealFileSync } from './vaultSync/SealFileSync';
 import { CSV_VIEW_EXTENSIONS, CSV_VIEW_TYPE, CSVView } from './view/CSVView';
 import { createSqlSealEditorExtension } from './editorExtension/inlineCodeBlock';
 import { ListRenderer } from './renderer/ListRenderer';
+import { TaskListRenderer } from './renderer/TaskListRenderer';
 import { JSON_VIEW_EXTENSIONS, JSON_VIEW_TYPE, JsonView } from './view/JsonView';
 import { CellParserRegistar } from './cellParser';
 import { registerAPI } from '@vanakat/plugin-api';
@@ -56,6 +57,7 @@ export default class SqlSealPlugin extends Plugin {
 		this.rendererRegistry.register('sql-seal-internal-grid', new GridRenderer(this.app, this, this.cellParserRegistar))
 		this.rendererRegistry.register('sql-seal-internal-markdown', new MarkdownRenderer(this.app))
 		this.rendererRegistry.register('sql-seal-internal-list', new ListRenderer(this.app, this.cellParserRegistar))
+		this.rendererRegistry.register('sql-seal-internal-tasklist', new TaskListRenderer(this.app, this.cellParserRegistar))
 		this.rendererRegistry.register('sql-seal-internal-template', new TemplateRenderer(this.app, this.cellParserRegistar))
 
 		// start syncing when files are loaded

--- a/src/renderer/TaskListRenderer.ts
+++ b/src/renderer/TaskListRenderer.ts
@@ -1,0 +1,75 @@
+// This is renderer for a very basic List view.
+import { App } from "obsidian";
+import { CellParser } from "../cellParser";
+import { RendererConfig } from "../renderer/rendererRegistry";
+import { displayError } from "../utils/ui";
+import { ViewDefinition } from "../grammar/parser";
+
+interface ListRendererConfig {
+    classNames: string[]
+}
+
+export class TaskListRenderer implements RendererConfig {
+
+    constructor(private readonly app: App, private readonly cellParser: CellParser) { }
+
+    get rendererKey() {
+        return 'tasklist'
+    }
+
+    get viewDefinition(): ViewDefinition {
+        return {
+            name: this.rendererKey,
+            argument: 'viewClassNames?',
+            singleLine: true
+        }
+    }
+
+    validateConfig(config: string): ListRendererConfig {
+        if (!config) {
+            return {
+                classNames: []
+            }
+        }
+        const classNames = config.split('.').filter(x => !!x).map(t => t.trim())
+        return {
+            classNames
+        }
+    }
+
+    render(config: ListRendererConfig, el: HTMLElement) {
+        return {
+            render: ({ columns, data }: any) => {
+                el.empty()
+				el.className='el-ul';
+				el.addClasses(['el-ul', ...config.classNames])
+
+				if (!columns.contains('checkbox') || !columns.contains('task')) {
+					displayError(el, 'Data must contain "checkbox" and "task" columns');
+					return;
+				}
+
+                const list = el.createEl("ul", {
+                    cls: ['contains-task-list', 'has-list-bullet']
+                })
+
+                data.forEach((d: any) => {
+					const row = list.createEl("li", { cls: ['task-list-item'] });
+					row.createSpan({ cls: ['list-bullet'] })
+					const checkbox = this.cellParser.render(d['checkbox']) as HTMLInputElement;
+					checkbox.className = 'task-list-item-checkbox';
+					row.append(checkbox);
+					row.appendText(d['task']);
+
+					if (checkbox.checked) {
+						row.addClass('is-checked');
+						row.setAttr('data-task', 'x');
+					}
+                });
+            },
+            error: (error: string) => {
+                displayError(el, error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Creates a new renderer (TASKLIST) that displays tasks as a list, styled just like normal task lists in obsidian. A couple of things I don't like about this approach:

- Two different renders to produce a list
- sqlseal style classes are not used, in favour of the inbuilt ones
- relies on having the appropriate checkbox and task columns, which must be named exactly

However, this can't really be accomplished any other way. I tried fooling with the template first, but it doesn't allow for direct DOM manipulation.

Let me know what you think, @kulak-at 