### PR TITLE
Fix: renderAsString was not working as intended for images.

### DIFF
--- a/src/cellParser/parser/checkbox.ts
+++ b/src/cellParser/parser/checkbox.ts
@@ -93,7 +93,7 @@ export class CheckboxParser implements CellFunction<Args> {
 
     renderAsString(values: Args): string {
         if (!isCheckboxProp(values)) {
-            if (!!values[0]) {
+            if (values[0]) {
                 return '[x]'
             }
             return '[ ]'

--- a/src/cellParser/parser/image.ts
+++ b/src/cellParser/parser/image.ts
@@ -53,14 +53,8 @@ export class ImageParser implements CellFunction<Args> {
     renderAsString([href, path]: Args): string {
         if (!isLinkLocal(href)) {
             return `![](${href})`
+        } else {
+            return `![[${href}]]`
         }
-
-        try {
-            const resourcePath = this.getResourcePath(href, path)
-            return `![[${resourcePath}]]`
-        } catch (e) {
-            return e.toString()
-        }
-
     }
 }

--- a/src/codeblockHandler/CodeblockProcessor.ts
+++ b/src/codeblockHandler/CodeblockProcessor.ts
@@ -73,7 +73,8 @@ export class CodeblockProcessor extends MarkdownRenderChild {
                 .prepareRender(
                     results.renderer.type.toLowerCase(), results.renderer.options
                 )(rendererEl, {
-                    cellParser: this.plugin.cellParser
+                    cellParser: this.plugin.cellParser,
+                    sourcePath: this.ctx.sourcePath
                 })
 
             // FIXME: probably should save the one before transform and perform transform every time we execute it.

--- a/src/renderer/rendererRegistry.ts
+++ b/src/renderer/rendererRegistry.ts
@@ -7,7 +7,8 @@ export interface DataFormat {
 }
 
 export interface RendererContext {
-    cellParser: ModernCellParser
+    cellParser: ModernCellParser,
+    sourcePath: string
 }
 
 export interface RenderReturn {


### PR DESCRIPTION
The `renderAsString` method for images returned unsatisfying results. See here:

![grafik](https://github.com/user-attachments/assets/aff2958f-6df3-426d-b19b-7d912d65b466)