### PR TITLE
Fix: changed the way how images are rendered as strings

### DIFF
--- a/src/cellParser/parser/checkbox.ts
+++ b/src/cellParser/parser/checkbox.ts
@@ -93,7 +93,7 @@ export class CheckboxParser implements CellFunction<Args> {
 
     renderAsString(values: Args): string {
         if (!isCheckboxProp(values)) {
-            if (!!values[0]) {
+            if (values[0]) {
                 return '[x]'
             }
             return '[ ]'

--- a/src/cellParser/parser/image.ts
+++ b/src/cellParser/parser/image.ts
@@ -53,14 +53,8 @@ export class ImageParser implements CellFunction<Args> {
     renderAsString([href, path]: Args): string {
         if (!isLinkLocal(href)) {
             return `![](${href})`
+        } else {
+            return `![[${href}]]`
         }
-
-        try {
-            const resourcePath = this.getResourcePath(href, path)
-            return `![[${resourcePath}]]`
-        } catch (e) {
-            return e.toString()
-        }
-
     }
 }


### PR DESCRIPTION
Using the existing `renderedAsString` resulted in unusable paths. See here (in the markdown renderer):

![grafik](https://github.com/user-attachments/assets/d84090d6-9dfa-40f5-952a-4a66165f5212)

With this change, the rendered string correctly links to the respective internal file and shows it accordingly if outputted directly into the md file:

![grafik](https://github.com/user-attachments/assets/90507ef6-9c9e-4ad3-b0d0-347c7e6a1228)
