### PR TITLE
Fix: added a new property to the render context: the file path the call originates from

### DIFF
--- a/src/codeblockHandler/CodeblockProcessor.ts
+++ b/src/codeblockHandler/CodeblockProcessor.ts
@@ -73,7 +73,8 @@ export class CodeblockProcessor extends MarkdownRenderChild {
                 .prepareRender(
                     results.renderer.type.toLowerCase(), results.renderer.options
                 )(rendererEl, {
-                    cellParser: this.plugin.cellParser
+                    cellParser: this.plugin.cellParser,
+                    sourcePath: this.ctx.sourcePath
                 })
 
             // FIXME: probably should save the one before transform and perform transform every time we execute it.

--- a/src/renderer/rendererRegistry.ts
+++ b/src/renderer/rendererRegistry.ts
@@ -7,7 +7,8 @@ export interface DataFormat {
 }
 
 export interface RendererContext {
-    cellParser: ModernCellParser
+    cellParser: ModernCellParser,
+    sourcePath: string
 }
 
 export interface RenderReturn {

--- a/src/view/CSVView.ts
+++ b/src/view/CSVView.ts
@@ -276,7 +276,7 @@ export class CSVView extends TextFileView {
                 })
                 menu.showAtMouseEvent(e.event as any)
             }
-        }, gridEl, { cellParser: this.cellParser })
+        }, gridEl, { cellParser: this.cellParser, sourcePath: this.file?.path || '' })
 
         this.api = api;
         this.loadDataIntoGrid()


### PR DESCRIPTION
It can be crucial for renderes to know which file initiated the respective render call. This can be realized by the newly added `RenderContext`.