### PR TITLE
fix: list properties were not correctly rendered for some renderer types

### DIFF
--- a/src/cellParser/ModernCellParser.ts
+++ b/src/cellParser/ModernCellParser.ts
@@ -43,6 +43,8 @@ export class ModernCellParser {
                             if (i < parsed.length -1) {
                                 container.appendChild(document.createTextNode(', '))
                             }
+                        } else if (typeof rendered === 'string') {
+                            container.textContent += `${rendered}${i < parsed.length - 1 ? ', ' : ''}`
                         }
                     })
                     return container


### PR DESCRIPTION
List properties were not correctly rendered for `GRID` and `HTML` renderer (I tested `TEMPLATE` separately). Here is an example (the files have a property named "friendsTo" which is a list):

Test 1: Grid

```sqlseal
GRID

SELECT name, friendsTo
FROM files
WHERE type IS "contact"
```

Test 2: HTML

```sqlseal
HTML

SELECT name, friendsTo
FROM files
WHERE type IS "contact"
```

Test 3: Markdown

```sqlseal
MARKDOWN

SELECT name, friendsTo
FROM files
WHERE type IS "contact"
```

This resulted in the following render:

![grafik](https://github.com/user-attachments/assets/72547031-975f-414c-a03e-f22fc3eb5c3d)

This pull request fixes that. However, I'm not sure if this is the intended fix. So please double-check.