### PR TITLE
Fix parsing of filename with commas in it

### DIFF
--- a/src/editorExtension/syntaxHighlight.ts
+++ b/src/editorExtension/syntaxHighlight.ts
@@ -87,11 +87,18 @@ export class SQLSealViewPlugin implements PluginValue {
       if (decorations) {
         decorations.forEach(dec => {
           if (dec.type === 'filename') {
+            let hasQuotes = false;
             // Get the actual filename text from the document
-            const filePath = view.state.doc.sliceString(
+            let filePath = view.state.doc.sliceString(
               contentStart + dec.start,
               contentStart + dec.end
             );
+
+            // Remove leading & trailing quotes, if captured.
+            if (filePath.startsWith('"')) {
+              filePath = filePath.substring(1, filePath.length - 1)
+              hasQuotes = true;
+            }
 
             // Create widget decoration for the filename
             const widget = new FilePathWidget(filePath, this.app);
@@ -99,8 +106,8 @@ export class SQLSealViewPlugin implements PluginValue {
               widget,
               inclusive: true
             }).range(
-              contentStart + dec.start,
-              contentStart + dec.end
+              contentStart + dec.start + Number(hasQuotes),
+              contentStart + dec.end - Number(hasQuotes)
             ));
           } else {
             const decoration = markDecorations[dec.type as keyof typeof markDecorations];

--- a/src/grammar/parser.test.ts
+++ b/src/grammar/parser.test.ts
@@ -49,6 +49,26 @@ describe('Ohm parser', () => {
         })
     })
 
+    it("should parse table expression with comma in name with name quoted", () => {
+        expect(parse('TABLE x = file("abcdef, ghijk.csv")', DEFAULT_VIEWS)).toEqual(
+            {
+                query: "",
+                tables: [
+                    {
+                        arguments: ["abcdef, ghijk.csv"],
+                        type: "file",
+                        tableAlias: "x",
+                    },
+                ],
+                flags: {},
+                renderer: {
+                    name: "GRID",
+                    options: "",
+                },
+            },
+        );
+    })
+
     it('should parse SELECT statement alone', () => {
         expect(parse('SELECT * FROM files', DEFAULT_VIEWS)).toEqual({
             query: 'SELECT * FROM files',

--- a/src/grammar/parser.ts
+++ b/src/grammar/parser.ts
@@ -38,7 +38,8 @@ export const SQLSealLangDefinition = (views: ViewDefinition[], flags: readonly F
             |                          tableOpening NonemptyListOf<listElement, ","> tableDefinitionClosing      -- mdtable
             TableFileExpressionArgs =  filename ("," NonemptyListOf<listElement, ",">)?
             identifier =               (alnum | "_")+
-            filename  =                (alnum | "." | "-" | space | "_" | "/" | "\\" | "$" | "[" | "]" | "\"")+
+            filename  =                ~("\"") (alnum | "." | "-" | space | "_" | "/" | "\\" | "$" | "[" | "]" | "\"")+ ~("\"") -- unquoted
+            |                          "\"" (alnum | "." | "-" | space | "_" | "/" | "\\" | "$" | "[" | "]" | ",")+ "\"" -- quoted
             fileOpening =              caseInsensitive<"file(">
             tableOpening =             caseInsensitive<"table(">
             tableDefinitionClosing =   ")"


### PR DESCRIPTION
If the filename is quoted, then it should allow commas in the name. The parsing of the filename terminates at the next quote.

Fixes #156.