### PR TITLE
fix(parser): support parentheses in filenames

### DIFF
--- a/src/modules/editor/parser.test.ts
+++ b/src/modules/editor/parser.test.ts
@@ -69,6 +69,54 @@ describe('Ohm parser', () => {
         );
     })
 
+    it('should parse table expression with parentheses in name with name quoted', () => {
+        expect(parse('TABLE x = file("abcdef (ghijk) (123).csv")', DEFAULT_VIEWS)).toEqual({
+            query: '',
+            tables: [{
+                arguments: ['abcdef (ghijk) (123).csv'],
+                type: 'file',
+                tableAlias: 'x'
+            }],
+            flags: {},
+            renderer: {
+                name: 'GRID',
+                options: ''
+            }
+        })
+    })
+
+    it('should parse table expression with parentheses in name unquoted', () => {
+        expect(parse('TABLE x = file(abcdef (ghijk) (123).csv)', DEFAULT_VIEWS)).toEqual({
+            query: '',
+            tables: [{
+                arguments: ['abcdef (ghijk) (123).csv'],
+                type: 'file',
+                tableAlias: 'x'
+            }],
+            flags: {},
+            renderer: {
+                name: 'GRID',
+                options: ''
+            }
+        })
+    })
+
+    it('should parse arguments following a quoted name with parentheses', () => {
+        expect(parse('TABLE x = file("abcdef (ghijk).json5", $.results[*])', DEFAULT_VIEWS)).toEqual({
+            query: '',
+            tables: [{
+                arguments: ['abcdef (ghijk).json5', '$.results[*]'],
+                type: 'file',
+                tableAlias: 'x'
+            }],
+            flags: {},
+            renderer: {
+                name: 'GRID',
+                options: ''
+            }
+        })
+    })
+
     it('should parse SELECT statement alone', () => {
         expect(parse('SELECT * FROM files', DEFAULT_VIEWS)).toEqual({
             query: 'SELECT * FROM files',

--- a/src/modules/editor/parser.ts
+++ b/src/modules/editor/parser.ts
@@ -38,8 +38,10 @@ export const SQLSealLangDefinition = (views: ViewDefinition[], flags: readonly F
             |                          tableOpening NonemptyListOf<listElement, ","> tableDefinitionClosing      -- mdtable
             TableFileExpressionArgs =  filename ("," NonemptyListOf<listElement, ",">)?
             identifier =               (alnum | "_")+
-            filename  =                ~("\"") (alnum | "." | "-" | space | "_" | "/" | "\\" | "$" | "[" | "]" | "\"")+ ~("\"") -- unquoted
-            |                          "\"" (alnum | "." | "-" | space | "_" | "/" | "\\" | "$" | "[" | "]" | ",")+ "\"" -- quoted
+            filename  =                "\"" (~"\"" any)+ "\"" -- quoted
+            |                          unquotedFilenamePart+ -- unquoted
+            unquotedFilenamePart =     "(" unquotedFilenamePart* ")" -- balanced
+            |                          (alnum | "." | "-" | space | "_" | "/" | "\\" | "$" | "[" | "]") -- plain
             fileOpening =              caseInsensitive<"file(">
             tableOpening =             caseInsensitive<"table(">
             tableDefinitionClosing =   ")"


### PR DESCRIPTION
The `filename` rule used a character whitelist that omitted `(` and `)`. Double-quoted names now accept any character up to the closing `"`, and unquoted names match balanced parens, so a bare `)` still terminates the `file(...)` expression.

Fixes #217

Let me know if you'd prefer to extend the whitelist instead, but this would eliminate the need to maintain one at all.